### PR TITLE
Add-suffix-prefix-for-user-agent-in-lm-data-sdk-java

### DIFF
--- a/buildSrc/src/main/groovy/com.logicmonitor.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.logicmonitor.java-conventions.gradle
@@ -16,7 +16,7 @@ dependencies {
 }
 
 group = 'com.logicmonitor'
-version = '0.0.3-alpha'
+version = '0.0.4-alpha'
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 

--- a/data-sdk/build.gradle
+++ b/data-sdk/build.gradle
@@ -72,8 +72,6 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:4.3.1'
-    testImplementation "com.github.stefanbirkner:system-lambda:1.0.0"
-
 }
 
 task codeCoverageReport(type: JacocoReport) {

--- a/data-sdk/build.gradle
+++ b/data-sdk/build.gradle
@@ -72,6 +72,8 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:4.3.1'
+    testImplementation "com.github.stefanbirkner:system-lambda:1.0.0"
+
 }
 
 task codeCoverageReport(type: JacocoReport) {
@@ -81,9 +83,9 @@ task codeCoverageReport(type: JacocoReport) {
         sourceSets it.sourceSets.main
     }
     reports {
-        xml.enabled true
+        xml.enabled false
         xml.destination file("${buildDir}/reports/jacoco/report.xml")
-        html.enabled false
+        html.enabled true
         csv.enabled false
     }
     afterEvaluate {

--- a/data-sdk/build.gradle
+++ b/data-sdk/build.gradle
@@ -83,9 +83,9 @@ task codeCoverageReport(type: JacocoReport) {
         sourceSets it.sourceSets.main
     }
     reports {
-        xml.enabled false
+        xml.enabled true
         xml.destination file("${buildDir}/reports/jacoco/report.xml")
-        html.enabled true
+        html.enabled false
         csv.enabled false
     }
     afterEvaluate {

--- a/data-sdk/src/main/java/com/logicmonitor/sdk/data/ApiClientUserAgent.java
+++ b/data-sdk/src/main/java/com/logicmonitor/sdk/data/ApiClientUserAgent.java
@@ -15,6 +15,10 @@ public class ApiClientUserAgent extends ApiClient {
   Setup setup = new Setup();
 
   public ApiClientUserAgent() {
+    String applicationName = "";
+    if (System.getenv("APPLICATION_NAME") != null) {
+      applicationName = "/" + System.getenv("APPLICATION_NAME");
+    }
     setUserAgent(
         String.format(setup.getPACKAGE_ID())
             .concat(
@@ -25,7 +29,8 @@ public class ApiClientUserAgent extends ApiClient {
                     + setup.getOS_NAME()
                     + ";arch "
                     + setup.getARCH()
-                    + ")"));
+                    + ")"
+                    + applicationName));
   }
 
   /**

--- a/data-sdk/src/main/java/com/logicmonitor/sdk/data/ApiClientUserAgent.java
+++ b/data-sdk/src/main/java/com/logicmonitor/sdk/data/ApiClientUserAgent.java
@@ -29,10 +29,6 @@ public class ApiClientUserAgent extends ApiClient {
   }
 
   public ApiClientUserAgent(String userAgentSuffix) {
-    String applicationName = "";
-    if (userAgentSuffix != null && userAgentSuffix.length() <= 32) {
-      applicationName = "/" + userAgentSuffix;
-    }
     setUserAgent(
         String.format(setup.getPACKAGE_ID())
             .concat(
@@ -44,7 +40,7 @@ public class ApiClientUserAgent extends ApiClient {
                     + ";arch "
                     + setup.getARCH()
                     + ")"
-                    + applicationName));
+                    + userAgentSuffix));
   }
 
   /**

--- a/data-sdk/src/main/java/com/logicmonitor/sdk/data/ApiClientUserAgent.java
+++ b/data-sdk/src/main/java/com/logicmonitor/sdk/data/ApiClientUserAgent.java
@@ -15,9 +15,23 @@ public class ApiClientUserAgent extends ApiClient {
   Setup setup = new Setup();
 
   public ApiClientUserAgent() {
+    setUserAgent(
+        String.format(setup.getPACKAGE_ID())
+            .concat(
+                setup.getPACKAGE_VERSION()
+                    + " (Java "
+                    + setup.getJAVA_VERSION()
+                    + ";"
+                    + setup.getOS_NAME()
+                    + ";arch "
+                    + setup.getARCH()
+                    + ")"));
+  }
+
+  public ApiClientUserAgent(String userAgentSuffix) {
     String applicationName = "";
-    if (System.getenv("APPLICATION_NAME") != null) {
-      applicationName = "/" + System.getenv("APPLICATION_NAME");
+    if (userAgentSuffix != null && userAgentSuffix.length() <= 32) {
+      applicationName = "/" + userAgentSuffix;
     }
     setUserAgent(
         String.format(setup.getPACKAGE_ID())

--- a/data-sdk/src/main/java/com/logicmonitor/sdk/data/internal/BatchingCache.java
+++ b/data-sdk/src/main/java/com/logicmonitor/sdk/data/internal/BatchingCache.java
@@ -9,6 +9,7 @@ package com.logicmonitor.sdk.data.internal;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import com.logicmonitor.sdk.data.ApiClientUserAgent;
 import com.logicmonitor.sdk.data.Configuration;
 import com.logicmonitor.sdk.data.model.*;
 import java.io.ByteArrayOutputStream;
@@ -184,7 +185,7 @@ public abstract class BatchingCache {
       boolean gZip)
       throws ApiException, IOException {
 
-    final ApiClient apiClient = new ApiClient();
+    final ApiClientUserAgent apiClient = new ApiClientUserAgent();
     final Pair pair = new Pair("create", String.valueOf(create));
     final List<Pair> queryParams = new ArrayList<>();
     final List<Pair> collectionQueryParams = new ArrayList<>();

--- a/data-sdk/src/main/java/com/logicmonitor/sdk/data/internal/BatchingCache.java
+++ b/data-sdk/src/main/java/com/logicmonitor/sdk/data/internal/BatchingCache.java
@@ -185,7 +185,7 @@ public abstract class BatchingCache {
       boolean gZip)
       throws ApiException, IOException {
 
-    final ApiClientUserAgent apiClient = new ApiClientUserAgent();
+    final ApiClientUserAgent apiClient = new ApiClientUserAgent(System.getenv("APPLICATION_NAME"));
     final Pair pair = new Pair("create", String.valueOf(create));
     final List<Pair> queryParams = new ArrayList<>();
     final List<Pair> collectionQueryParams = new ArrayList<>();

--- a/data-sdk/src/main/java/com/logicmonitor/sdk/data/internal/BatchingCache.java
+++ b/data-sdk/src/main/java/com/logicmonitor/sdk/data/internal/BatchingCache.java
@@ -185,7 +185,8 @@ public abstract class BatchingCache {
       boolean gZip)
       throws ApiException, IOException {
 
-    final ApiClientUserAgent apiClient = new ApiClientUserAgent(System.getenv("APPLICATION_NAME"));
+    String userAgentSuffix = getUserAgentSuffix(System.getenv("APPLICATION_NAME"));
+    final ApiClientUserAgent apiClient = new ApiClientUserAgent(userAgentSuffix);
     final Pair pair = new Pair("create", String.valueOf(create));
     final List<Pair> queryParams = new ArrayList<>();
     final List<Pair> collectionQueryParams = new ArrayList<>();
@@ -343,5 +344,13 @@ public abstract class BatchingCache {
    */
   public static void setStartTime(long startTime) {
     BatchingCache.startTime = startTime;
+  }
+
+  public String getUserAgentSuffix(String userAgentSuffix) {
+    String applicationName = "";
+    if (userAgentSuffix != null && userAgentSuffix.length() <= 32) {
+      applicationName = "/" + userAgentSuffix;
+    }
+    return applicationName;
   }
 }

--- a/data-sdk/src/test/java/com/logicmonitor/sdk/data/TestApiClientUserAgent.java
+++ b/data-sdk/src/test/java/com/logicmonitor/sdk/data/TestApiClientUserAgent.java
@@ -24,4 +24,19 @@ public class TestApiClientUserAgent {
     ApiClient apiClientUserAgent = apiClient.setUserAgent(userAgent);
     Assertions.assertEquals(apiClient, apiClientUserAgent);
   }
+
+  @Test
+  public void testUserAgentWithSuffix() {
+    ApiClientUserAgent apiClient = new ApiClientUserAgent("test-application");
+    ApiClient apiClientUserAgent = apiClient.setUserAgent(userAgent);
+    Assertions.assertEquals(apiClient, apiClientUserAgent);
+  }
+
+  @Test
+  public void testUserAgentWithSuffixGreaterThan32Char() {
+    ApiClientUserAgent apiClient =
+        new ApiClientUserAgent("test-application-application-name-32char");
+    ApiClient apiClientUserAgent = apiClient.setUserAgent(userAgent);
+    Assertions.assertEquals(apiClient, apiClientUserAgent);
+  }
 }

--- a/data-sdk/src/test/java/com/logicmonitor/sdk/data/TestApiClientUserAgent.java
+++ b/data-sdk/src/test/java/com/logicmonitor/sdk/data/TestApiClientUserAgent.java
@@ -7,8 +7,6 @@
  */
 package com.logicmonitor.sdk.data;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
-
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.openapitools.client.ApiClient;
@@ -25,16 +23,5 @@ public class TestApiClientUserAgent {
   public void testUserAgent() {
     ApiClient apiClientUserAgent = apiClient.setUserAgent(userAgent);
     Assertions.assertEquals(apiClient, apiClientUserAgent);
-  }
-
-  @Test
-  public void testUserAgentWithApplicationName() throws Exception {
-    withEnvironmentVariable("APPLICATION_NAME", "test-user-agent")
-        .execute(
-            () -> {
-              ApiClientUserAgent apiClient = new ApiClientUserAgent();
-              ApiClient apiClientUserAgent = apiClient.setUserAgent(userAgent);
-              Assertions.assertEquals(apiClient, apiClientUserAgent);
-            });
   }
 }

--- a/data-sdk/src/test/java/com/logicmonitor/sdk/data/TestApiClientUserAgent.java
+++ b/data-sdk/src/test/java/com/logicmonitor/sdk/data/TestApiClientUserAgent.java
@@ -31,12 +31,4 @@ public class TestApiClientUserAgent {
     ApiClient apiClientUserAgent = apiClient.setUserAgent(userAgent);
     Assertions.assertEquals(apiClient, apiClientUserAgent);
   }
-
-  @Test
-  public void testUserAgentWithSuffixGreaterThan32Char() {
-    ApiClientUserAgent apiClient =
-        new ApiClientUserAgent("test-application-application-name-32char");
-    ApiClient apiClientUserAgent = apiClient.setUserAgent(userAgent);
-    Assertions.assertEquals(apiClient, apiClientUserAgent);
-  }
 }

--- a/data-sdk/src/test/java/com/logicmonitor/sdk/data/TestApiClientUserAgent.java
+++ b/data-sdk/src/test/java/com/logicmonitor/sdk/data/TestApiClientUserAgent.java
@@ -7,6 +7,8 @@
  */
 package com.logicmonitor.sdk.data;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
+
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.openapitools.client.ApiClient;
@@ -23,5 +25,16 @@ public class TestApiClientUserAgent {
   public void testUserAgent() {
     ApiClient apiClientUserAgent = apiClient.setUserAgent(userAgent);
     Assertions.assertEquals(apiClient, apiClientUserAgent);
+  }
+
+  @Test
+  public void testUserAgentWithApplicationName() throws Exception {
+    withEnvironmentVariable("APPLICATION_NAME", "test-user-agent")
+        .execute(
+            () -> {
+              ApiClientUserAgent apiClient = new ApiClientUserAgent();
+              ApiClient apiClientUserAgent = apiClient.setUserAgent(userAgent);
+              Assertions.assertEquals(apiClient, apiClientUserAgent);
+            });
   }
 }

--- a/data-sdk/src/test/java/com/logicmonitor/sdk/data/internal/TestBatchingCache.java
+++ b/data-sdk/src/test/java/com/logicmonitor/sdk/data/internal/TestBatchingCache.java
@@ -156,4 +156,16 @@ public class TestBatchingCache {
     boolean var = batchingCache.checkNumberOfRequest("log/ingest");
     Assert.assertEquals(var, Boolean.TRUE);
   }
+
+  @Test
+  public void testUserAgentWithSuffixGreaterThan32Char() {
+    String testString = "test-application-application-name-32char";
+    Assertions.assertEquals("", batchingCache.getUserAgentSuffix(testString));
+  }
+
+  @Test
+  public void testUserAgentWithSuffix() {
+    String testString = "test-application";
+    Assertions.assertEquals("/test-application", batchingCache.getUserAgentSuffix(testString));
+  }
 }

--- a/data-sdk/src/test/java/com/logicmonitor/sdk/data/validator/TestDataSourceInstanceValidator.java
+++ b/data-sdk/src/test/java/com/logicmonitor/sdk/data/validator/TestDataSourceInstanceValidator.java
@@ -89,6 +89,16 @@ public class TestDataSourceInstanceValidator {
   }
 
   @Test
+  public void providedInvalidInstancePropertiesValues() {
+    String expected =
+        "Invalid instance properties value : 1!@#$%^&*() for Key : instancePropertyKey.";
+    Map<String, String> instanceProperties = new HashMap<>();
+    instanceProperties.put("instancePropertyKey", "1!@#$%^&*()");
+    Assertions.assertEquals(
+        expected, instanceValidator.checkInstancePropertiesValidation(instanceProperties));
+  }
+
+  @Test
   public void testPassEmptyAndSpellCheck() {
     Assertions.assertEquals(true, instanceValidator.passEmptyAndSpellCheck(" DataSourceInstance"));
   }


### PR DESCRIPTION
Appending applicationName as suffix to the user-agent 
 For example applicationName is lm-logs-azure, The user-agent will now go as
 logicmonitor_data_sdk/0.0.1.alpha (Java 11.0.12;Mac OS X;arch x86_64)/lm-logs-azure